### PR TITLE
Remove typo in Sponsors link

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -52,7 +52,7 @@ import NoOrphanText from "../components/NoOrphanText.astro"
     <h2>Want to sponsor our event?</h2>
     <p>
     <img src="/pyconau-sponsor-image-banner.jpeg" alt="Photo of platinum sponsors' logos advertised at PyCon AU 2023" style="border-radius: 0.5rem;"/>
-      Sponsors are critical to the success of PyCon AU. We're always looking to connect with sponsors and have a range of packages and benefits to suit organisations of all shapes and sizes! To learn more about how sponsors can support the conference, check out our <a href="/sponsor'">sponsorships page</a>.
+      Sponsors are critical to the success of PyCon AU. We're always looking to connect with sponsors and have a range of packages and benefits to suit organisations of all shapes and sizes! To learn more about how sponsors can support the conference, check out our <a href="/sponsor">sponsorships page</a>.
     <center>
       <Button type="chonk" block href="/files/PyCon%20AU%202024%20-%20Sponsorship%20Prospectus%20-%20July%20Update.pdf">
         Download the Sponsorship Prospectus


### PR DESCRIPTION
Somebody let the sponsorship team near the website again, huh.