### PR TITLE
Move program back to original location

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,6 +10,6 @@ export default defineConfig({
   },
   integrations: [mdx()],
   redirects: {
-    '/program': '/pycon-au-2024/schedule'
-  }
+    "/pycon-au-2024/schedule": "/program",
+  },
 })

--- a/src/pages/program/index.astro
+++ b/src/pages/program/index.astro
@@ -1,0 +1,23 @@
+---
+import Base from "../../layouts/Base.astro"
+---
+
+<Base title="Program">
+    <script type="text/javascript" src="/widgets/schedule.js" async></script>
+    <pretalx-schedule
+      event-url="/pycon-au-2024/"
+      version="20240903.1"
+      locale="en"
+      timezone="Australia/Melbourne"
+      style="--pretalx-clr-primary: #00B159"></pretalx-schedule>
+    <noscript>
+      <div class="alert alert-info m-4">
+        <div></div>
+        <div>
+          To see our schedule, please either enable JavaScript or go <a
+            href="/pycon-au-2024/schedule/nojs">here</a
+          > for our NoJS schedule.
+        </div>
+      </div>
+    </noscript>
+</Base>


### PR DESCRIPTION
Prior to this change, the program was available only at a peculiar URL,
and was shown as a Pretalx embed on a page that featured CSS from the
home page, but with incorrect fonts in places, layout issues, and
missing navigation components.

This change retains the Pretalx embed, but moves it back to the expected
location for the schedule. It also replaces the custom HTML with the
base page Astro component, restoring the correct fonts and navigation,
and the correct styles for a page that isn't the home page.

<img width="1232" alt="Screenshot 2024-09-05 at 14 21 54" src="https://github.com/user-attachments/assets/f27b7354-48af-4022-bdbe-0f1acaa68982">
