### PR TITLE
Parametrise sponsor tiers

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,12 +1,16 @@
 import { z, defineCollection } from "astro:content"
-import { ROOM_SLUGS, SPECIALIST_TRACK_SLUGS } from "../main_config"
+import {
+  ROOM_SLUGS,
+  SPECIALIST_TRACK_SLUGS,
+  SPONSOR_TIER_SLUGS,
+} from "../main_config"
 
 const sponsors = defineCollection({
   schema: z.object({
     name: z.string(),
     logo: z.string(),
     url: z.string(),
-    tier: z.string(),
+    tier: z.enum(SPONSOR_TIER_SLUGS),
   }),
 })
 const pages = defineCollection({

--- a/src/main_config.ts
+++ b/src/main_config.ts
@@ -13,15 +13,25 @@ export const SPECIALIST_TRACKS = [
   { slug: "education", name: "Education", room: "eureka3" },
 ] as const
 
+export const SPONSOR_TIERS = [
+  { slug: "gold", name: "Gold Sponsor", plural_name: "Gold Sponsors" },
+  { slug: "standard", name: "Sponsor", plural_name: "Sponsors" },
+  { slug: "auspice", name: "Auspice", plural_name: "Auspices" },
+] as const
+
 // -----
 
 export type RoomSlug = (typeof ROOMS)[number]["slug"]
+export type SponsorTierSlug = (typeof SPONSOR_TIERS)[number]["slug"]
 type ExtractSlug<T extends readonly { slug: any }[]> = {
   [I in keyof T]: T[I]["slug"]
 }
 export const ROOM_SLUGS = ROOMS.map((room) => room.slug) as any as ExtractSlug<
   typeof ROOMS
 >
+export const SPONSOR_TIER_SLUGS = SPONSOR_TIERS.map(
+  (tier) => tier.slug,
+) as any as ExtractSlug<typeof SPONSOR_TIERS>
 export const SPECIALIST_TRACK_SLUGS = SPECIALIST_TRACKS.map(
   (track) => track.slug,
 ) as any as ExtractSlug<typeof SPECIALIST_TRACKS>

--- a/src/pages/sponsor.astro
+++ b/src/pages/sponsor.astro
@@ -3,6 +3,7 @@ import { getCollection, getEntryBySlug } from "astro:content"
 import Base from "../layouts/Base.astro"
 import Button from "../components/Button.astro"
 import SponsorListing from "../components/SponsorListing.astro"
+import { SPONSOR_TIERS } from "../main_config"
 // Get all entries from a collection. Requires the name of the collection as an argument.
 
 const allSponsors = await getCollection("sponsors")
@@ -65,79 +66,17 @@ and of course <a href="#auspice">Linux Australia</a>!
 */
     }
 
-    {
-      platinum.length > 0 && (
-        <>
-          <h2 id="platinum">Platinum Sponsor{platinum.length !== 1 && "s"}</h2>
-          {platinum.map((sponsor) => (
-            <SponsorListing sponsor={sponsor} />
-          ))}
-        </>
-      )
-    }
+    {SPONSOR_TIERS.map(tier => {
+      const sponsors = allSponsors.filter(sponsor => sponsor.data.tier == tier.slug)
+      if (!sponsors.length) return <></>
+      return <>
+      <h2 id={tier.slug}>{sponsors.length === 1 ? tier.name : tier.plural_name}</h2>
+      {sponsors.map(sponsor => <SponsorListing sponsor={sponsor}/>)}
+      </>
+    })}
 
     {
-      gold.length > 0 && (
-        <>
-          <h2 id="gold">Gold Sponsor{gold.length !== 1 && "s"}</h2>
-          {gold.map((sponsor) => (
-            <SponsorListing sponsor={sponsor} />
-          ))}
-        </>
-      )
-    }
-
-    {
-      track.length > 0 && (
-        <>
-          <h2 id="track">Track Sponsor{track.length !== 1 && "s"}</h2>
-          {track.map((sponsor) => (
-            <SponsorListing sponsor={sponsor} />
-          ))}
-        </>
-      )
-    }
-
-    {
-      /*
-
-{% if contributors %}
-<a name="contributors"></a>
-<h1>Contributor{% if contributors | length != 1 %}s{% endif %}</h1>
-<p>
-  We thank everyone who <a href="/attend/">purchased a Contributor ticket</a>.
-  They are directly helping fund our financial assistance efforts for future
-  events:
-</p>
-
-<ul class="contributor-sponsors">
-{% for s in contributors %}
-  <li>
-	{{s.title}} {% if s.attribution %}{{s.attribution}}{% endif %}
-  </li>
-{% endfor %}
-</ul>
-
-<hr />
-{% endif %}
-
-
-<a name="media"></a>
-<table>
-  {% for s in specialsponsor %} {{m.special(s)}} {% endfor %}
-</table>
-
-<h1>Auspice</h1>
-
-<a name="auspice"></a>
-  {% for s in auspice %} {{m.sponsor(s)}} {% endfor %}
-  
-*/
-    }
-
-    <h1 id="auspice">Auspice</h1>
-    <SponsorListing sponsor={auspice} />
-
+      
     <h1 id="opportunities">Sponsorship Opportunities</h1>
 
     <Content />

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,16 +1,15 @@
 import { getCollection, CollectionEntry } from "astro:content"
+import { SPONSOR_TIERS, SponsorTierSlug } from "./main_config"
 
 type SponsorsByTier = {
-  tier: "platinum" | "gold" | "track" | "auspice"
+  tier: SponsorTierSlug
   sponsors: CollectionEntry<"sponsors">[]
 }[]
 
-const data: SponsorsByTier = [
-  { tier: "platinum", sponsors: [] },
-  { tier: "gold", sponsors: [] },
-  { tier: "track", sponsors: [] },
-  { tier: "auspice", sponsors: [] },
-]
+const data: SponsorsByTier = SPONSOR_TIERS.map((tier) => ({
+  tier: tier.slug,
+  sponsors: [],
+}))
 let dataIsPopulated = false
 
 export async function getSponsorsByTier(): Promise<SponsorsByTier> {


### PR DESCRIPTION
Adds a configuration option to `src/main_config.ts` that allows the sponsor tiers to be configured in one place. This should allow the sponsor added in #41 to be displayed.