### PR TITLE
fix: ensure space between day and hour on program

### DIFF
--- a/src/pages/program/[sessionId].astro
+++ b/src/pages/program/[sessionId].astro
@@ -101,8 +101,7 @@ const daySlug = DateTime.fromJSDate(entry.data.start, {
         /* prettier-ignore */ <div class="time-bar">
           {DateTime.fromJSDate(entry.data.start, { zone: "Australia/Adelaide"}).toLocaleString(
             {weekday: 'long'},
-          )}
-          {DateTime.fromJSDate(entry.data.start, { zone: "Australia/Adelaide"}).toLocaleString(
+          )}&nbsp;{DateTime.fromJSDate(entry.data.start, { zone: "Australia/Adelaide"}).toLocaleString(
             DateTime.TIME_SIMPLE,
           )}&ndash;{DateTime.fromJSDate(entry.data.end, { zone: "Australia/Adelaide"}).toLocaleString(
             DateTime.TIME_SIMPLE,
@@ -143,7 +142,7 @@ const daySlug = DateTime.fromJSDate(entry.data.start, {
     {speakers.map((speaker) => <Profile person={speaker} bio />)}
   </main>
   {
-    /* 
+    /*
 {% for person in session.speakers %}
   {{ m.profile(person, bio=True) }}
 {% endfor %}


### PR DESCRIPTION
Fixes a small visual error on program pages

Before: No visible space between day of week and hour of day

![Before, lack of space](https://github.com/user-attachments/assets/aedd1769-7693-4160-a786-6eb3eff1de90)

After: Space!

![After, space. (The final frontier) ](https://github.com/user-attachments/assets/daf572e9-3884-4c40-ac3e-3a874886eba1)
